### PR TITLE
fix typo yed->yet

### DIFF
--- a/bsd-user/linux/os-sys.c
+++ b/bsd-user/linux/os-sys.c
@@ -1248,7 +1248,7 @@ static inline void sysctl_oidfmt(uint32_t *holdp)
 #if defined(__linux__)
 static inline int sysctlnametomib(const char *name, int *mibp, size_t *sizep)
 {
-	qemu_log("sysctlnametomib(%s): not implemented yed\n", name);
+	qemu_log("sysctlnametomib(%s): not implemented yet\n", name);
 	return -TARGET_ENOENT;
 }
 


### PR DESCRIPTION
when running ping in the container:

```sh
# ping github.com/
sysctlnametomib(kern.features.inet): not implemented yed
sysctlnametomib(kern.features.inet6): not implemented yed
ping: cannot resolve github.com/: Name does not resolve
```